### PR TITLE
add typecast for size_t

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -126,11 +126,11 @@ rapidjson::Value method_get_state(const rapidjson::Value& /* params */, const ra
 	std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
 
 	res.SetObject();
-	res.AddMember("speed", worker.last_speed, allocator);
+	res.AddMember("speed", static_cast<uint64_t>(worker.last_speed), allocator);
 	res.AddMember("best", worker.last_best, allocator);
-	res.AddMember("max_round", worker.rounds, allocator);
-	res.AddMember("round", worker.cur_round, allocator);
-	res.AddMember("popsize", worker.popsize, allocator);
+	res.AddMember("max_round", static_cast<uint64_t>(worker.rounds), allocator);
+	res.AddMember("round", static_cast<uint64_t>(worker.cur_round), allocator);
+	res.AddMember("popsize", static_cast<uint64_t>(worker.popsize), allocator);
 	res.AddMember("save_dir",
 	              rapidjson::Value().SetString(worker.save_dir.c_str(), allocator),
 	              allocator);


### PR DESCRIPTION
1) Add me to collaborators if its possible pls.
2) compiling on mac os got error with

```
leonid@Shehobook nlab % gcc --std=c++14 neuron.cpp tweann.cpp g_lab.cpp remote_env.cpp main.cpp -DNDEBUG -lpthread -O -o nlab
In file included from main.cpp:15:
In file included from ./json_routines.h:4:
/usr/local/include/rapidjson/document.h:1259:22: error: call to constructor of 'rapidjson::GenericValue<rapidjson::UTF8<char>,
      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >' is ambiguous
        GenericValue v(value);
                     ^ ~~~~~
/usr/local/include/rapidjson/document.h:1330:16: note: in instantiation of function template specialization 'rapidjson::GenericValue<rapidjson::UTF8<char>,
      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::AddMember<unsigned long>' requested here
        return AddMember(n, value, allocator);
               ^
main.cpp:129:6: note: in instantiation of function template specialization 'rapidjson::GenericValue<rapidjson::UTF8<char>,
      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::AddMember<unsigned long>' requested here
        res.AddMember("speed", worker.last_speed, allocator);
            ^
/usr/local/include/rapidjson/document.h:634:14: note: candidate constructor
    explicit GenericValue(int i) RAPIDJSON_NOEXCEPT : data_() {
             ^
/usr/local/include/rapidjson/document.h:640:14: note: candidate constructor
    explicit GenericValue(unsigned u) RAPIDJSON_NOEXCEPT : data_() {
             ^
/usr/local/include/rapidjson/document.h:646:14: note: candidate constructor
    explicit GenericValue(int64_t i64) RAPIDJSON_NOEXCEPT : data_() {
             ^
/usr/local/include/rapidjson/document.h:661:14: note: candidate constructor
    explicit GenericValue(uint64_t u64) RAPIDJSON_NOEXCEPT : data_() {
             ^
/usr/local/include/rapidjson/document.h:673:14: note: candidate constructor
    explicit GenericValue(double d) RAPIDJSON_NOEXCEPT : data_() { data_.n.d = d; data_.f.flags = kNumberDoubleFlag; }
             ^
1 error generated.
```

so i decided to cast size_t values to uint64_t 

that worked for me. 

Describe if something wrong with this decision.